### PR TITLE
[1.5.0] Cut Release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@tacoinfra/harbinger-lib",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -479,9 +479,9 @@
             }
         },
         "bl": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
-            "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+            "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
             "requires": {
                 "buffer": "^5.5.0",
                 "inherits": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tacoinfra/harbinger-lib",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Common typescript code which powers the CLI and Serverless updaters.",
   "main": "build/src/index.js",
   "files": [


### PR DESCRIPTION
This release pulls in new exports and smart contracts. 

I'll run `npm publish` offline and annotate this PR. 