### PR TITLE
[1.7.0] Cut Release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@tacoinfra/harbinger-lib",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@tacoinfra/harbinger-lib",
-    "version": "1.6.0",
+    "version": "1.7.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tacoinfra/harbinger-lib",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Common typescript code which powers the CLI and Serverless updaters.",
   "main": "build/src/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clean": "rm -rf ./build",
     "lint": "eslint . --ext .ts --fix",
     "test": "npm run lint && jest",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build && npm test"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tacoinfra/harbinger-lib",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Common typescript code which powers the CLI and Serverless updaters.",
   "main": "build/src/index.js",
   "files": [

--- a/src/update.ts
+++ b/src/update.ts
@@ -68,7 +68,7 @@ export default async function updateOracleFromCoinbase(
   updateIntervalSeconds: number | undefined,
   tezosNodeURL: string,
   normalizerContractAddress: string | undefined = undefined,
-  enableZeroFees: boolean = false
+  enableZeroFees = false,
 ): Promise<void> {
   if (logLevel == LogLevel.Debug) {
     Utils.print('Using node located at: ' + tezosNodeURL)
@@ -99,7 +99,7 @@ export default async function updateOracleFromCoinbase(
         signer,
         tezosNodeURL,
         normalizerContractAddress,
-        enableZeroFees
+        enableZeroFees,
       )
 
       Utils.print(
@@ -119,7 +119,7 @@ export default async function updateOracleFromCoinbase(
       signer,
       tezosNodeURL,
       normalizerContractAddress,
-      enableZeroFees
+      enableZeroFees,
     )
   }
 }
@@ -151,7 +151,7 @@ export async function updateOracleFromCoinbaseOnce(
   signer: Signer,
   tezosNodeURL: string,
   normalizerContractAddress: string | undefined = undefined,
-  enableZeroFees: boolean = false
+  enableZeroFees = false,
 ): Promise<string> {
   try {
     await Utils.revealAccountIfNeeded(tezosNodeURL, keyStore, signer)
@@ -160,9 +160,9 @@ export async function updateOracleFromCoinbaseOnce(
     if (logLevel == LogLevel.Debug) {
       Utils.print(
         'Using assets: ' +
-        assetNames.reduce((previousValue, assetName) => {
-          return previousValue + assetName + ', '
-        }, ''),
+          assetNames.reduce((previousValue, assetName) => {
+            return previousValue + assetName + ', '
+          }, ''),
       )
     }
     Utils.print('')
@@ -196,7 +196,10 @@ export async function updateOracleFromCoinbaseOnce(
       operations.push(normalizerPushOperation)
     }
 
-    const operationFeeEstimator = new OperationFeeEstimator(tezosNodeURL, enableZeroFees)
+    const operationFeeEstimator = new OperationFeeEstimator(
+      tezosNodeURL,
+      enableZeroFees,
+    )
     const operationsWithFees = await operationFeeEstimator.estimateAndApplyFees(
       operations,
     )
@@ -243,7 +246,7 @@ export async function updateOracleFromFeed(
   updateIntervalSeconds: number | undefined,
   tezosNodeURL: string,
   normalizerContractAddress: string | undefined = undefined,
-  enableZeroFees: boolean = false
+  enableZeroFees = false,
 ): Promise<void> {
   if (logLevel == LogLevel.Debug) {
     Utils.print('Using node located at: ' + tezosNodeURL)
@@ -272,7 +275,7 @@ export async function updateOracleFromFeed(
         signer,
         tezosNodeURL,
         normalizerContractAddress,
-        enableZeroFees
+        enableZeroFees,
       )
 
       Utils.print(
@@ -290,7 +293,7 @@ export async function updateOracleFromFeed(
       signer,
       tezosNodeURL,
       normalizerContractAddress,
-      enableZeroFees
+      enableZeroFees,
     )
   }
 }
@@ -318,7 +321,7 @@ export async function updateOracleFromFeedOnce(
   signer: Signer,
   tezosNodeURL: string,
   normalizerContractAddress: string | undefined = undefined,
-  enableZeroFees: boolean = false
+  enableZeroFees = false,
 ): Promise<string> {
   try {
     await Utils.revealAccountIfNeeded(tezosNodeURL, keyStore, signer)
@@ -327,9 +330,9 @@ export async function updateOracleFromFeedOnce(
     if (logLevel == LogLevel.Debug) {
       Utils.print(
         'Using assets: ' +
-        assetNames.reduce((previousValue, assetName) => {
-          return previousValue + assetName + ', '
-        }, ''),
+          assetNames.reduce((previousValue, assetName) => {
+            return previousValue + assetName + ', '
+          }, ''),
       )
     }
     Utils.print('')
@@ -361,7 +364,10 @@ export async function updateOracleFromFeedOnce(
       operations.push(normalizerPushOperation)
     }
 
-    const operationFeeEstimator = new OperationFeeEstimator(tezosNodeURL, enableZeroFees)
+    const operationFeeEstimator = new OperationFeeEstimator(
+      tezosNodeURL,
+      enableZeroFees,
+    )
     const operationsWithFees = await operationFeeEstimator.estimateAndApplyFees(
       operations,
     )

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,5 @@
     },
     "include": [
         "src/*.ts",
-        "__tests__/**/*.ts"
     ]
 }


### PR DESCRIPTION
Cut release 1.6.0 of `@tacoinfra/harbinger-lib`. Also modify `publish` command to run tests prior to releasing. 

This release contains support for zero-fee update operations. 

Will run `npm publish` offline.